### PR TITLE
add floating point gauge

### DIFF
--- a/metrics/expvar/expvar.go
+++ b/metrics/expvar/expvar.go
@@ -57,6 +57,22 @@ func (g *gauge) Add(delta int64) { g.v.Add(delta) }
 
 func (g *gauge) Set(value int64) { g.v.Set(value) }
 
+type gaugeFloat struct {
+	v *expvar.Float
+}
+
+// NewGaugeFloat returns a new GaugeFloat backed by an expvar with the given name.
+// Fields are ignored.
+func NewGaugeFloat(name string) metrics.GaugeFloat {
+	return &gaugeFloat{expvar.NewFloat(name)}
+}
+
+func (g *gaugeFloat) With(metrics.Field) metrics.GaugeFloat { return g }
+
+func (g *gaugeFloat) Add(delta float64) { g.v.Add(delta) }
+
+func (g *gaugeFloat) Set(value float64) { g.v.Set(value) }
+
 type histogram struct {
 	mu   sync.Mutex
 	hist *hdrhistogram.WindowedHistogram

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -21,6 +21,14 @@ type Gauge interface {
 	Add(delta int64)
 }
 
+// GaugeFloat captures instantaneous measurements of something using 64 bit
+// floating point number. The value does not need to be monotonic.
+type GaugeFloat interface {
+	With(Field) GaugeFloat
+	Set(value float64)
+	Add(delta float64)
+}
+
 // Histogram tracks the distribution of a stream of values (e.g. the number of
 // milliseconds it takes to handle requests). Implementations may choose to
 // add gauges for values at meaningful quantiles.

--- a/metrics/prometheus/prometheus_test.go
+++ b/metrics/prometheus/prometheus_test.go
@@ -66,6 +66,26 @@ func TestPrometheusGauge(t *testing.T) {
 	}
 }
 
+func TestPrometheusGaugeFloat(t *testing.T) {
+	c := prometheus.NewGaugeFloat("test", "prometheus_gaugeFloat", "foobar", "Dolor sit.", []string{})
+	c.Set(42.5)
+	if want, have := strings.Join([]string{
+		`# HELP test_prometheus_gaugeFloat_foobar Dolor sit.`,
+		`# TYPE test_prometheus_gaugeFloat_foobar gauge`,
+		`test_prometheus_gaugeFloat_foobar 42.5`,
+	}, "\n"), teststat.ScrapePrometheus(t); !strings.Contains(have, want) {
+		t.Errorf("metric stanza not found or incorrect\n%s", have)
+	}
+	c.Add(-43.5)
+	if want, have := strings.Join([]string{
+		`# HELP test_prometheus_gaugeFloat_foobar Dolor sit.`,
+		`# TYPE test_prometheus_gaugeFloat_foobar gauge`,
+		`test_prometheus_gaugeFloat_foobar -1`,
+	}, "\n"), teststat.ScrapePrometheus(t); !strings.Contains(have, want) {
+		t.Errorf("metric stanza not found or incorrect\n%s", have)
+	}
+}
+
 func TestPrometheusHistogram(t *testing.T) {
 	h := prometheus.NewHistogram("test", "prometheus_histogram", "foobar", "Qwerty asdf.", []string{})
 

--- a/rfc/rfc003-package-metrics.md
+++ b/rfc/rfc003-package-metrics.md
@@ -21,6 +21,8 @@ http://peter.bourgon.org/go-kit/#package-metrics
 
 - Gauge SHALL be an arbitrarily-settable register of type int64.
 
+- GaugeFloat SHALL be an arbitrarily-settable register of type float64.
+
 - Histogram SHALL collect observations of type int64.
 
 - These interfaces SHALL be the primary and exclusive API for metrics.
@@ -44,6 +46,12 @@ type Gauge interface {
 	With(Field) Gauge
 	Set(value int64)
 	Add(delta int64)
+}
+
+type GaugeFloat interface {
+	With(Field) GaugeFloat
+	Set(value float64)
+	Add(delta float64)
 }
 ```
 


### PR DESCRIPTION
The current spec only contains an integer based gauge. Many metrics of interest are sometimes expressed as floating point numbers; load average being an example. This proposal extends the metric interface to include a floating point gauge.

I have not extended the statsd interface because I'm unfamiliar with with its protocol.