### PR TITLE
metrics: add callback-style constructors for Gauges

### DIFF
--- a/metrics/expvar/expvar_test.go
+++ b/metrics/expvar/expvar_test.go
@@ -1,6 +1,8 @@
 package expvar_test
 
 import (
+	stdexpvar "expvar"
+	"fmt"
 	"testing"
 
 	"github.com/peterbourgon/gokit/metrics/expvar"
@@ -15,4 +17,13 @@ func TestHistogramQuantiles(t *testing.T) {
 	const seed, mean, stdev int64 = 424242, 50, 10
 	teststat.PopulateNormalHistogram(t, h, seed, mean, stdev)
 	teststat.AssertExpvarNormalHistogram(t, metricName, mean, stdev, quantiles)
+}
+
+func TestCallbackGauge(t *testing.T) {
+	value := 42.43
+	metricName := "foo"
+	expvar.PublishCallbackGauge(metricName, func() float64 { return value })
+	if want, have := fmt.Sprint(value), stdexpvar.Get(metricName).String(); want != have {
+		t.Errorf("want %q, have %q", want, have)
+	}
 }

--- a/metrics/prometheus/prometheus.go
+++ b/metrics/prometheus/prometheus.go
@@ -111,6 +111,29 @@ func (g prometheusGauge) Add(delta float64) {
 	g.GaugeVec.With(prometheus.Labels(g.Pairs)).Add(delta)
 }
 
+// RegisterCallbackGauge registers a Gauge with Prometheus whose value is
+// determined at collect time by the passed callback function. The callback
+// determines the value, and fields are ignored, so RegisterCallbackGauge
+// returns nothing.
+func RegisterCallbackGauge(namespace, subsystem, name, help string, callback func() float64) {
+	RegisterCallbackGaugeWithLabels(namespace, subsystem, name, help, prometheus.Labels{}, callback)
+}
+
+// RegisterCallbackGaugeWithLabels is the same as RegisterCallbackGauge, but
+// attaches a set of const label pairs to the metric.
+func RegisterCallbackGaugeWithLabels(namespace, subsystem, name, help string, constLabels prometheus.Labels, callback func() float64) {
+	prometheus.MustRegister(prometheus.NewGaugeFunc(
+		prometheus.GaugeOpts{
+			Namespace:   namespace,
+			Subsystem:   subsystem,
+			Name:        name,
+			Help:        help,
+			ConstLabels: constLabels,
+		},
+		callback,
+	))
+}
+
 type prometheusHistogram struct {
 	*prometheus.SummaryVec
 	Pairs map[string]string

--- a/metrics/prometheus/prometheus_test.go
+++ b/metrics/prometheus/prometheus_test.go
@@ -66,6 +66,19 @@ func TestPrometheusGauge(t *testing.T) {
 	}
 }
 
+func TestPrometheusCallbackGauge(t *testing.T) {
+	value := 123.456
+	cb := func() float64 { return value }
+	prometheus.RegisterCallbackGauge("test", "prometheus_gauge", "bazbaz", "Help string.", cb)
+	if want, have := strings.Join([]string{
+		`# HELP test_prometheus_gauge_bazbaz Help string.`,
+		`# TYPE test_prometheus_gauge_bazbaz gauge`,
+		`test_prometheus_gauge_bazbaz 123.456`,
+	}, "\n"), teststat.ScrapePrometheus(t); !strings.Contains(have, want) {
+		t.Errorf("metric stanza not found or incorrect\n%s", have)
+	}
+}
+
 func TestPrometheusHistogram(t *testing.T) {
 	h := prometheus.NewHistogram("test", "prometheus_histogram", "foobar", "Qwerty asdf.", []string{})
 

--- a/metrics/statsd/statsd.go
+++ b/metrics/statsd/statsd.go
@@ -30,14 +30,14 @@ const maxBufferSize = 1400 // bytes
 type statsdCounter chan string
 
 // NewCounter returns a Counter that emits observations in the statsd protocol
-// to the passed writer. Observations are buffered for the reporting interval
-// or until the buffer exceeds a max packet size, whichever comes first.
-// Fields are ignored.
+// to the passed writer. Observations are buffered for the report interval or
+// until the buffer exceeds a max packet size, whichever comes first. Fields
+// are ignored.
 //
 // TODO: support for sampling.
-func NewCounter(w io.Writer, key string, interval time.Duration) metrics.Counter {
+func NewCounter(w io.Writer, key string, reportInterval time.Duration) metrics.Counter {
 	c := make(chan string)
-	go fwd(w, key, interval, c)
+	go fwd(w, key, reportInterval, c)
 	return statsdCounter(c)
 }
 
@@ -48,14 +48,14 @@ func (c statsdCounter) Add(delta uint64) { c <- fmt.Sprintf("%d|c", delta) }
 type statsdGauge chan string
 
 // NewGauge returns a Gauge that emits values in the statsd protocol to the
-// passed writer. Values are buffered for the reporting interval or until the
+// passed writer. Values are buffered for the report interval or until the
 // buffer exceeds a max packet size, whichever comes first. Fields are
 // ignored.
 //
 // TODO: support for sampling.
-func NewGauge(w io.Writer, key string, interval time.Duration) metrics.Gauge {
+func NewGauge(w io.Writer, key string, reportInterval time.Duration) metrics.Gauge {
 	g := make(chan string)
-	go fwd(w, key, interval, g)
+	go fwd(w, key, reportInterval, g)
 	return statsdGauge(g)
 }
 
@@ -72,6 +72,25 @@ func (g statsdGauge) Add(delta float64) {
 
 func (g statsdGauge) Set(value float64) {
 	g <- fmt.Sprintf("%f|g", value)
+}
+
+// NewCallbackGauge emits values in the statsd protocol to the passed writer.
+// It collects values every scrape interval from the callback. Values are
+// buffered for the report interval or until the buffer exceeds a max packet
+// size, whichever comes first. The report and scrape intervals may be the
+// same. Fields are ignored.
+func NewCallbackGauge(w io.Writer, key string, reportInterval, scrapeInterval time.Duration, callback func() float64) {
+	go fwd(w, key, reportInterval, emitEvery(scrapeInterval, callback))
+}
+
+func emitEvery(d time.Duration, f func() float64) <-chan string {
+	c := make(chan string)
+	go func() {
+		for range time.Tick(d) {
+			c <- fmt.Sprintf("%f|g", f())
+		}
+	}()
+	return c
 }
 
 type statsdHistogram chan string
@@ -93,9 +112,9 @@ type statsdHistogram chan string
 //    NewTimeHistogram(statsdHistogram, time.Millisecond)
 //
 // TODO: support for sampling.
-func NewHistogram(w io.Writer, key string, interval time.Duration) metrics.Histogram {
+func NewHistogram(w io.Writer, key string, reportInterval time.Duration) metrics.Histogram {
 	h := make(chan string)
-	go fwd(w, key, interval, h)
+	go fwd(w, key, reportInterval, h)
 	return statsdHistogram(h)
 }
 
@@ -107,9 +126,9 @@ func (h statsdHistogram) Observe(value int64) {
 
 var tick = time.Tick
 
-func fwd(w io.Writer, key string, interval time.Duration, c chan string) {
+func fwd(w io.Writer, key string, reportInterval time.Duration, c <-chan string) {
 	buf := &bytes.Buffer{}
-	tick := tick(interval)
+	tick := tick(reportInterval)
 	for {
 		select {
 		case s := <-c:


### PR DESCRIPTION
In package metrics, we define the interfaces for use by the producer (client app) and leave the details of exposition (to statsd, to Prometheus, etc.) to the specific implementation.

Some implementations will statelessly send every observation directly to the aggregation layer (e.g. statsd); some will statefully collect observations and make them available for scrape heartbeats (e.g. Prometheus).

The semantics that @bensigelman wants [here](https://github.com/peterbourgon/gokit/pull/6/files#r26010599) are actually coupled to implementations that _have_ monitoring heartbeats. We want to support those implementations without necessarily relying on them.

This PR introduces new callback-based Gauge constructors for app code that's built that way. Since the callback is the sole authority for the value of the Gauge, those constructors simply Register or Publish the metric, and return nothing. That's fine: callbacks can be shared.

We also include an adapter for statsd, emitting callback-based Gauges to a statsd aggregator on some interval.

Eager for comments.
