### PR TITLE
Reduce allocations performed by the Logger returned from log.With.

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -39,8 +39,8 @@ type withLogger struct {
 	keyvals []interface{}
 }
 
-func (l *withLogger) Log(kvs ...interface{}) error {
-	return l.logger.Log(append(l.keyvals, kvs...)...)
+func (l *withLogger) Log(keyvals ...interface{}) error {
+	return l.logger.Log(append(l.keyvals, keyvals...)...)
 }
 
 func (l *withLogger) With(keyvals ...interface{}) Logger {

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -78,3 +78,46 @@ func TestWithConcurrent(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkDiscard(b *testing.B) {
+	logger := log.NewDiscardLogger()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		logger.Log("k", "v")
+	}
+}
+
+func BenchmarkOneWith(b *testing.B) {
+	logger := log.NewDiscardLogger()
+	logger = log.With(logger, "k", "v")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		logger.Log("k", "v")
+	}
+}
+
+func BenchmarkTwoWith(b *testing.B) {
+	logger := log.NewDiscardLogger()
+	for i := 0; i < 2; i++ {
+		logger = log.With(logger, "k", "v")
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		logger.Log("k", "v")
+	}
+}
+
+func BenchmarkTenWith(b *testing.B) {
+	logger := log.NewDiscardLogger()
+	for i := 0; i < 10; i++ {
+		logger = log.With(logger, "k", "v")
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		logger.Log("k", "v")
+	}
+}


### PR DESCRIPTION
The old method performed O(n) allocs, the new method is O(1), where n is the number of nested With contexts.

(Note: this PR also adds NewDiscardLogger() to the API. It is used in the new benchmarks, but also has other uses, so I thought it should be exported.)

```
benchmark                           old ns/op     new ns/op     delta
BenchmarkJSONLoggerSimple           7075          7005          -0.99%
BenchmarkJSONLoggerContextual       10195         9345          -8.34%
BenchmarkDiscard                    386           388           +0.52%
BenchmarkOneWith                    729           728           -0.14%
BenchmarkTwoWith                    1191          932           -21.75%
BenchmarkTenWith                    8735          2416          -72.34%
BenchmarkPrefixLoggerSimple         2002          2015          +0.65%
BenchmarkPrefixLoggerContextual     4186          3993          -4.61%

benchmark                           old allocs     new allocs     delta
BenchmarkJSONLoggerSimple           19             19             +0.00%
BenchmarkJSONLoggerContextual       30             28             -6.67%
BenchmarkDiscard                    3              3              +0.00%
BenchmarkOneWith                    4              4              +0.00%
BenchmarkTwoWith                    5              4              -20.00%
BenchmarkTenWith                    13             4              -69.23%
BenchmarkPrefixLoggerSimple         5              5              +0.00%
BenchmarkPrefixLoggerContextual     13             11             -15.38%

benchmark                           old bytes     new bytes     delta
BenchmarkJSONLoggerSimple           812           812           +0.00%
BenchmarkJSONLoggerContextual       1158          1159          +0.09%
BenchmarkDiscard                    64            64            +0.00%
BenchmarkOneWith                    128           128           +0.00%
BenchmarkTwoWith                    224           192           -14.29%
BenchmarkTenWith                    2144          704           -67.16%
BenchmarkPrefixLoggerSimple         145           145           +0.00%
BenchmarkPrefixLoggerContextual     403           402           -0.25%
```