### PR TITLE
add mangos to related projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Projects with a ★ have had particular influence on gokit's design.
 - [spacemonkeygo/monitor](https://github.com/spacemonkeygo/monitor), data collection, monitoring, instrumentation, and Zipkin client library
 - [streadway/handy](https://github.com/streadway/handy), net/http handler filters
 - [vitess/rpcplus](https://godoc.org/code.google.com/p/vitess/go/rpcplus), package rpc + context.Context
+- [gdamore/mangos](https://github.com/gdamore/mangos), nanomsg implementation in pure Go
 
 ### Web frameworks
 


### PR DESCRIPTION
I noticed that mangos was not mentioned, it's an excellent Go implementation of nanomsg (zeromq successor).