### PR TITLE
Support dynamic values in log contexts.

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -19,6 +19,9 @@ type Logger interface {
 //
 // If logger implements the Wither interface, the result of
 // logger.With(keyvals...) is returned.
+//
+// When wrapping a basic Logger, With returns a logger that calls BindValues
+// on the stored keyvals when logging.
 func With(logger Logger, keyvals ...interface{}) Logger {
 	w, ok := logger.(Wither)
 	if !ok {
@@ -33,7 +36,7 @@ type withLogger struct {
 }
 
 func (l *withLogger) Log(keyvals ...interface{}) error {
-	return l.logger.Log(append(l.keyvals, keyvals...)...)
+	return l.logger.Log(append(BindValues(l.keyvals...), keyvals...)...)
 }
 
 func (l *withLogger) With(keyvals ...interface{}) Logger {
@@ -61,6 +64,9 @@ func (f LoggerFunc) Log(keyvals ...interface{}) error {
 // A Wither creates Loggers that include keyvals in all log events.
 //
 // The With function uses Wither if available.
+//
+// It is recommended that implementations of With call BindValues on stored
+// keyvals before each log event.
 type Wither interface {
 	With(keyvals ...interface{}) Logger
 }

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/peterbourgon/gokit/log"
 )
 
+var discard = log.Logger(log.LoggerFunc(func(...interface{}) error { return nil }))
+
 func TestWith(t *testing.T) {
 	buf := &bytes.Buffer{}
 	kvs := []interface{}{"a", 123}
@@ -22,20 +24,6 @@ func TestWith(t *testing.T) {
 		t.Errorf("\nwant: %s\nhave: %s", want, have)
 	}
 }
-
-func TestWither(t *testing.T) {
-	logger := &mylogger{}
-	log.With(logger, "a", "b").Log("c", "d")
-	if want, have := 1, logger.withs; want != have {
-		t.Errorf("want %d, have %d", want, have)
-	}
-}
-
-type mylogger struct{ withs int }
-
-func (l *mylogger) Log(keyvals ...interface{}) error { return nil }
-
-func (l *mylogger) With(keyvals ...interface{}) log.Logger { l.withs++; return l }
 
 // Test that With returns a Logger safe for concurrent use. This test
 // validates that the stored logging context does not get corrupted when
@@ -82,7 +70,7 @@ func TestWithConcurrent(t *testing.T) {
 }
 
 func BenchmarkDiscard(b *testing.B) {
-	logger := log.NewDiscardLogger()
+	logger := discard
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -91,7 +79,7 @@ func BenchmarkDiscard(b *testing.B) {
 }
 
 func BenchmarkOneWith(b *testing.B) {
-	logger := log.NewDiscardLogger()
+	logger := discard
 	logger = log.With(logger, "k", "v")
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -101,7 +89,7 @@ func BenchmarkOneWith(b *testing.B) {
 }
 
 func BenchmarkTwoWith(b *testing.B) {
-	logger := log.NewDiscardLogger()
+	logger := discard
 	for i := 0; i < 2; i++ {
 		logger = log.With(logger, "k", "v")
 	}
@@ -113,7 +101,7 @@ func BenchmarkTwoWith(b *testing.B) {
 }
 
 func BenchmarkTenWith(b *testing.B) {
-	logger := log.NewDiscardLogger()
+	logger := discard
 	for i := 0; i < 10; i++ {
 		logger = log.With(logger, "k", "v")
 	}

--- a/log/value.go
+++ b/log/value.go
@@ -1,0 +1,68 @@
+package log
+
+import (
+	"time"
+
+	"gopkg.in/stack.v1"
+)
+
+// BindValues returns a slice with all value elements (odd indexes) that
+// implement Valuer replaced with the result of calling their Value method. If
+// no value elements implement Valuer, the original slice is returned.
+func BindValues(keyvals ...interface{}) []interface{} {
+	if !containsValuer(keyvals) {
+		return keyvals
+	}
+
+	bound := make([]interface{}, len(keyvals))
+	copy(bound, keyvals)
+	for i := 1; i < len(bound); i += 2 {
+		if v, ok := bound[i].(Valuer); ok {
+			bound[i] = v.Value()
+		}
+	}
+
+	return bound
+}
+
+func containsValuer(keyvals []interface{}) bool {
+	for i := 1; i < len(keyvals); i += 2 {
+		if _, ok := keyvals[i].(Valuer); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// Value is the return type of the Value method of the Valuer interface.
+type Value interface{}
+
+// A Valuer is able to convert itself into log Value.
+//
+// A Valuer passed to With stores a dynamic value which is reevaluated on each
+// log event.
+type Valuer interface {
+	// Value returns a log Value instead of an interface{} to avoid
+	// inadvertently matching types from packages not intended for use with
+	// the gokit/log package.
+	Value() Value
+}
+
+type timeStamp struct{}
+
+func (*timeStamp) Value() Value {
+	return time.Now()
+}
+
+// Timestamp is a Valuer that returns the result of time.Now() from its Value method.
+var Timestamp = &timeStamp{}
+
+type caller struct{}
+
+func (*caller) Value() Value {
+	return stack.Caller(3)
+}
+
+// Caller is a Valuer that returns a "gopkg.in/stack.v1".Call from its Value
+// method.
+var Caller = &caller{}

--- a/log/value.go
+++ b/log/value.go
@@ -10,9 +10,9 @@ import (
 // dynamic value which is re-evaluated with each log event.
 type Valuer func() interface{}
 
-// BindValues returns a slice with all value elements (odd indexes) that
-// implement Valuer replaced with the result of calling their Value method. If
-// no value elements implement Valuer, the original slice is returned.
+// BindValues returns a slice with all value elements (odd indexes) containing
+// a Valuer replaced by their generated value. If no Valuers are found, the
+// original slice is returned.
 func BindValues(keyvals ...interface{}) []interface{} {
 	if !containsValuer(keyvals) {
 		return keyvals
@@ -39,26 +39,32 @@ func containsValuer(keyvals []interface{}) bool {
 }
 
 var (
-	// Timestamp returns a Valuer that invokes the underlying function when bound,
-	// returning a time.Time. Users will probably want to use DefaultTimestamp or
-	// DefaultTimestampUTC.
+	// Timestamp returns a Valuer that invokes the underlying function when
+	// bound, returning a time.Time. Users will probably want to use
+	// DefaultTimestamp or DefaultTimestampUTC.
 	Timestamp = func(t func() time.Time) Valuer {
 		return func() interface{} { return t() }
 	}
-	// DefaultTimestamp is a Timestamp Valuer that returns the current wallclock
-	// time, respecting time zones, when bound.
+
+	// DefaultTimestamp is a Timestamp Valuer that returns the current
+	// wallclock time, respecting time zones, when bound.
 	DefaultTimestamp = Timestamp(time.Now)
+
 	// DefaultTimestampUTC wraps DefaultTimestamp but ensures the returned
 	// time is always in UTC. Note that it invokes DefaultTimestamp, and so
 	// reflects any changes to the DefaultTimestamp package global.
 	DefaultTimestampUTC = Timestamp(func() time.Time {
 		return DefaultTimestamp().(time.Time).UTC()
 	})
-	// Caller is a Valuer that returns a file and line from a specified depth in
-	// the callstack. Users will probably want to use DefaultCaller.
+)
+
+var (
+	// Caller is a Valuer that returns a file and line from a specified depth
+	// in the callstack. Users will probably want to use DefaultCaller.
 	Caller = func(depth int) Valuer {
 		return func() interface{} { return stack.Caller(depth) }
 	}
+
 	// DefaultCaller is a Valuer that returns the file and line where the Log
 	// method was invoked.
 	DefaultCaller = Caller(3)

--- a/log/value.go
+++ b/log/value.go
@@ -38,14 +38,14 @@ func containsValuer(keyvals []interface{}) bool {
 	return false
 }
 
-var (
-	// Timestamp returns a Valuer that invokes the underlying function when
-	// bound, returning a time.Time. Users will probably want to use
-	// DefaultTimestamp or DefaultTimestampUTC.
-	Timestamp = func(t func() time.Time) Valuer {
-		return func() interface{} { return t() }
-	}
+// Timestamp returns a Valuer that invokes the underlying function when bound,
+// returning a time.Time. Users will probably want to use DefaultTimestamp or
+// DefaultTimestampUTC.
+func Timestamp(t func() time.Time) Valuer {
+	return func() interface{} { return t() }
+}
 
+var (
 	// DefaultTimestamp is a Timestamp Valuer that returns the current
 	// wallclock time, respecting time zones, when bound.
 	DefaultTimestamp = Timestamp(time.Now)
@@ -58,13 +58,13 @@ var (
 	})
 )
 
-var (
-	// Caller is a Valuer that returns a file and line from a specified depth
-	// in the callstack. Users will probably want to use DefaultCaller.
-	Caller = func(depth int) Valuer {
-		return func() interface{} { return stack.Caller(depth) }
-	}
+// Caller returns a Valuer that returns a file and line from a specified depth
+// in the callstack. Users will probably want to use DefaultCaller.
+func Caller(depth int) Valuer {
+	return func() interface{} { return stack.Caller(depth) }
+}
 
+var (
 	// DefaultCaller is a Valuer that returns the file and line where the Log
 	// method was invoked.
 	DefaultCaller = Caller(3)

--- a/log/value.go
+++ b/log/value.go
@@ -11,12 +11,10 @@ type Value interface{}
 
 // A Valuer generates a log value. When passed to With, it represents a
 // dynamic value which is re-evaluated with each log event.
-type Valuer interface {
-	// Value returns a log Value instead of an interface{} to avoid
-	// inadvertently matching types from packages not intended for use with
-	// gokit/log.
-	Value() Value
-}
+// It returns a log Value instead of an interface{} to avoid
+// inadvertently matching types from packages not intended for use with
+// gokit/log.
+type Valuer func() Value
 
 // BindValues returns a slice with all value elements (odd indexes) that
 // implement Valuer replaced with the result of calling their Value method. If
@@ -30,7 +28,7 @@ func BindValues(keyvals ...interface{}) []interface{} {
 	copy(bound, keyvals)
 	for i := 1; i < len(bound); i += 2 {
 		if v, ok := bound[i].(Valuer); ok {
-			bound[i] = v.Value()
+			bound[i] = v()
 		}
 	}
 
@@ -46,32 +44,28 @@ func containsValuer(keyvals []interface{}) bool {
 	return false
 }
 
-// Timestamp is a Valuer that invokes the underlying function when bound,
-// returning a time.Time. Users will probably want to use DefaultTimestamp or
-// DefaultTimestampUTC.
-type Timestamp func() time.Time
-
-// Value implements Valuer.
-func (t Timestamp) Value() Value { return t() }
-
-// Caller is a Valuer that returns a file and line from a specified depth in
-// the callstack. Users will probably want to use DefaultCaller.
-type Caller int
-
-// Value implements Valuer.
-func (c Caller) Value() Value { return stack.Caller(int(c)) }
-
 var (
+	// Timestamp returns a Valuer that invokes the underlying function when bound,
+	// returning a time.Time. Users will probably want to use DefaultTimestamp or
+	// DefaultTimestampUTC.
+	Timestamp = func(t func() time.Time) Valuer {
+		return func() Value { return t() }
+	}
 	// DefaultTimestamp is a Timestamp Valuer that returns the current wallclock
 	// time, respecting time zones, when bound.
-	DefaultTimestamp Timestamp = time.Now
-
+	DefaultTimestamp = Timestamp(time.Now)
 	// DefaultTimestampUTC wraps DefaultTimestamp but ensures the returned
 	// time is always in UTC. Note that it invokes DefaultTimestamp, and so
 	// reflects any changes to the DefaultTimestamp package global.
-	DefaultTimestampUTC Timestamp = func() time.Time { return DefaultTimestamp().UTC() }
-
+	DefaultTimestampUTC = Timestamp(func() time.Time {
+		return DefaultTimestamp().(time.Time).UTC()
+	})
+	// Caller is a Valuer that returns a file and line from a specified depth in
+	// the callstack. Users will probably want to use DefaultCaller.
+	Caller = func(depth int) Valuer {
+		return func() Value { return stack.Caller(depth) }
+	}
 	// DefaultCaller is a Valuer that returns the file and line where the Log
 	// method was invoked.
-	DefaultCaller = Caller(4)
+	DefaultCaller = Caller(3)
 )

--- a/log/value.go
+++ b/log/value.go
@@ -6,15 +6,9 @@ import (
 	"gopkg.in/stack.v1"
 )
 
-// Value is the return type of the Value method of the Valuer interface.
-type Value interface{}
-
 // A Valuer generates a log value. When passed to With, it represents a
 // dynamic value which is re-evaluated with each log event.
-// It returns a log Value instead of an interface{} to avoid
-// inadvertently matching types from packages not intended for use with
-// gokit/log.
-type Valuer func() Value
+type Valuer func() interface{}
 
 // BindValues returns a slice with all value elements (odd indexes) that
 // implement Valuer replaced with the result of calling their Value method. If
@@ -49,7 +43,7 @@ var (
 	// returning a time.Time. Users will probably want to use DefaultTimestamp or
 	// DefaultTimestampUTC.
 	Timestamp = func(t func() time.Time) Valuer {
-		return func() Value { return t() }
+		return func() interface{} { return t() }
 	}
 	// DefaultTimestamp is a Timestamp Valuer that returns the current wallclock
 	// time, respecting time zones, when bound.
@@ -63,7 +57,7 @@ var (
 	// Caller is a Valuer that returns a file and line from a specified depth in
 	// the callstack. Users will probably want to use DefaultCaller.
 	Caller = func(depth int) Valuer {
-		return func() Value { return stack.Caller(depth) }
+		return func() interface{} { return stack.Caller(depth) }
 	}
 	// DefaultCaller is a Valuer that returns the file and line where the Log
 	// method was invoked.

--- a/log/value.go
+++ b/log/value.go
@@ -6,13 +6,14 @@ import (
 	"gopkg.in/stack.v1"
 )
 
-// A Valuer generates a log value. When passed to With, it represents a
-// dynamic value which is re-evaluated with each log event.
+// A Valuer generates a log value. When passed to With in a value element (odd
+// indexes), it represents a dynamic value which is re-evaluated with each log
+// event.
 type Valuer func() interface{}
 
-// BindValues replaces all value elements (odd indexes) containing a Valuer
+// bindValues replaces all value elements (odd indexes) containing a Valuer
 // with their generated value.
-func BindValues(keyvals []interface{}) {
+func bindValues(keyvals []interface{}) {
 	for i := 1; i < len(keyvals); i += 2 {
 		if v, ok := keyvals[i].(Valuer); ok {
 			keyvals[i] = v()
@@ -20,9 +21,9 @@ func BindValues(keyvals []interface{}) {
 	}
 }
 
-// ContainsValuer returns true if any of the value elements (odd indexes)
+// containsValuer returns true if any of the value elements (odd indexes)
 // contain a Valuer.
-func ContainsValuer(keyvals []interface{}) bool {
+func containsValuer(keyvals []interface{}) bool {
 	for i := 1; i < len(keyvals); i += 2 {
 		if _, ok := keyvals[i].(Valuer); ok {
 			return true

--- a/log/value_test.go
+++ b/log/value_test.go
@@ -52,7 +52,7 @@ func TestValueBinding(t *testing.T) {
 }
 
 func BenchmarkValueBindingTimestamp(b *testing.B) {
-	logger := log.NewDiscardLogger()
+	logger := discard
 	logger = log.With(logger, "ts", log.DefaultTimestamp)
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -62,7 +62,7 @@ func BenchmarkValueBindingTimestamp(b *testing.B) {
 }
 
 func BenchmarkValueBindingCaller(b *testing.B) {
-	logger := log.NewDiscardLogger()
+	logger := discard
 	logger = log.With(logger, "caller", log.DefaultCaller)
 	b.ReportAllocs()
 	b.ResetTimer()

--- a/log/value_test.go
+++ b/log/value_test.go
@@ -1,0 +1,58 @@
+package log_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/peterbourgon/gokit/log"
+)
+
+func TestValueBinding(t *testing.T) {
+	var output []interface{}
+	logger := log.Logger(log.LoggerFunc(func(keyvals ...interface{}) error {
+		output = keyvals
+		return nil
+	}))
+	logger = log.With(logger, "ts", log.Timestamp, "caller", log.Caller)
+
+	time.Sleep(50 * time.Millisecond)
+	before := time.Now()
+	logger.Log()
+	after := time.Now()
+
+	if _, ok := output[1].(time.Time); !ok {
+		t.Fatalf("output[1] type: want time.Time, have %T", output[1])
+	}
+	lt := output[1].(time.Time)
+	if before.After(lt) {
+		t.Errorf("output[1]: want on or after %v, have %v", before, lt)
+	}
+	if after.Before(lt) {
+		t.Errorf("output[1]: want on or before %v, have %v", after, lt)
+	}
+
+	if want, have := "value_test.go:21", fmt.Sprint(output[3]); want != have {
+		t.Fatalf("output[3]: want %s, have %s", want, have)
+	}
+}
+
+func BenchmarkValueBindingTime(b *testing.B) {
+	logger := log.NewDiscardLogger()
+	logger = log.With(logger, "ts", log.Timestamp)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		logger.Log("k", "v")
+	}
+}
+
+func BenchmarkValueBindingCaller(b *testing.B) {
+	logger := log.NewDiscardLogger()
+	logger = log.With(logger, "caller", log.Caller)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		logger.Log("k", "v")
+	}
+}


### PR DESCRIPTION
#### Goal

It is common to include a time-stamp and call-site or stack trace information in every log event in diagnostic logs. Package log should make it easy to add these fields when appropriate.

#### The Problem

Time-stamp and call-site values are dynamic, meaning the logged value changes with each call to `Log`. At the same time we usually want to make a global choice about whether to include them in our logs or not. These fields rapidly lose their value if they are not consistently available and having to specify them each time we call `Log` would be both tedious and error prone.

We could provide simple wrappers for `Logger` that injects the additional fields. This works nicely for time-stamps:

```go
func NewTimestampLogger(logger Logger, key interface{}) Logger {
    return LoggerFunc(func(keyvals ...interface{}) error {
        return logger.Log(append(keyvals, key, time.Now())
    })
}
```

But when we try the same for call-sites the details get ugly:

```go
func NewCallerLogger(logger Logger, key interface{}) Logger {
    return LoggerFunc(func(keyvals ...interface{}) error {
        // how many stack frames should we skip?
        _, file, line, ok := runtime.Caller(?skip?)
        return logger.Log(append(keyvals, key, fmt.Sprint(file, ":", line))
    })
}
```

Finding the call-site for `Log` depends on knowing how many stack frames to ascend? But that can change depending on the order we wrap the base `Logger`. Even if we are careful to always call `NewCallerLogger` last so that it is at the top of our logging stack it will likely get wrapped later by calls to `With`.

`NewCallerLogger` could implement the `Wither` interface to avoid getting wrapped by a `withLogger`. But this approach ends up essentially re-implementing `withLogger`.

#### The Solution

This PR recognizes that the above approaches are essentially specialized versions of `With`. They create a new logging context with a key and value. The essential difference is that the value is not static.

The proposed solution takes inspiration from package database/sql/driver. I propose a new `Valuer` interface similar to [`driver.Valuer`](http://golang.org/pkg/database/sql/driver/#Valuer). I also add a `BindValues` function to scan the values in a keyvals slice for `Valuers` and replace them with the result of their `Value` method. I modify `withLogger` to call `BindValues` when logging.

The result is an *extensible* mechanism for storing dynamic values in a logging context. Implementing `Timestamp` and `Caller` as commonly needed `Valuers` is trivial. Applications or other packages could use this capability to log other types of dynamic data. It seems like there could be some an interesting composition of this capability with package metrics for example.