### PR TITLE
Move HTTP bindings to package transport

### DIFF
--- a/addsvc/http_binding.go
+++ b/addsvc/http_binding.go
@@ -1,37 +1,14 @@
 package main
 
 import (
-	"encoding/json"
-	"io"
 	"net/http"
 	"time"
 
-	"golang.org/x/net/context"
-
 	"github.com/peterbourgon/gokit/metrics"
-	"github.com/peterbourgon/gokit/server"
 )
 
-// jsonCodec implements transport/codec, decoding and encoding requests and
-// responses respectively as JSON. It requires that the concrete request and
-// response types support JSON de/serialization.
-//
-// This type is mostly boiler-plate; in theory, it could be generated.
-type jsonCodec struct{}
-
-func (jsonCodec) Decode(ctx context.Context, r io.Reader) (server.Request, context.Context, error) {
-	var req request
-	err := json.NewDecoder(r).Decode(&req)
-	return &req, ctx, err
-}
-
-func (jsonCodec) Encode(w io.Writer, resp server.Response) error {
-	return json.NewEncoder(w).Encode(resp)
-}
-
-// The HTTP binding exists in the HTTP transport package, because it uses the
-// codec to deserialize and serialize requests and responses, and therefore
-// doesn't need to have access to the concrete request and response types.
+// HTTP bindings require no service-specific declarations, and so are defined
+// in transport/http.
 
 func httpInstrument(requests metrics.Counter, duration metrics.Histogram) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {

--- a/transport/codec/codec.go
+++ b/transport/codec/codec.go
@@ -12,6 +12,6 @@ import (
 // and returns a context because the request may be accompanied by information
 // that needs to be applied there.
 type Codec interface {
-	Decode(context.Context, io.Reader) (server.Request, context.Context, error)
+	Decode(context.Context, io.Reader, server.Request) (context.Context, error)
 	Encode(io.Writer, server.Response) error
 }

--- a/transport/codec/json/json.go
+++ b/transport/codec/json/json.go
@@ -1,0 +1,25 @@
+package json
+
+import (
+	"encoding/json"
+	"io"
+
+	"golang.org/x/net/context"
+
+	"github.com/peterbourgon/gokit/server"
+	"github.com/peterbourgon/gokit/transport/codec"
+)
+
+type jsonCodec struct{}
+
+// New returns a JSON codec. Request and response structures should have
+// properly-tagged fields.
+func New() codec.Codec { return jsonCodec{} }
+
+func (jsonCodec) Decode(ctx context.Context, r io.Reader, req server.Request) (context.Context, error) {
+	return ctx, json.NewDecoder(r).Decode(req)
+}
+
+func (jsonCodec) Encode(w io.Writer, resp server.Response) error {
+	return json.NewEncoder(w).Encode(resp)
+}

--- a/transport/codec/json/json_test.go
+++ b/transport/codec/json/json_test.go
@@ -1,0 +1,41 @@
+package json_test
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"golang.org/x/net/context"
+
+	jsoncodec "github.com/peterbourgon/gokit/transport/codec/json"
+)
+
+type request struct {
+	A int    `json:"a"`
+	B string `json:"b"`
+}
+
+type response struct {
+	Values []string `json:"values"`
+}
+
+func TestDecode(t *testing.T) {
+	buf := bytes.NewBufferString(`{"a":1,"b":"2"}`)
+	var req request
+	if _, err := jsoncodec.New().Decode(context.Background(), buf, &req); err != nil {
+		t.Fatal(err)
+	}
+	if want, have := (request{A: 1, B: "2"}), req; !reflect.DeepEqual(want, have) {
+		t.Errorf("want %v, have %v", want, have)
+	}
+}
+
+func TestEncode(t *testing.T) {
+	buf := &bytes.Buffer{}
+	if err := jsoncodec.New().Encode(buf, response{Values: []string{"a", "b", "c"}}); err != nil {
+		t.Fatal(err)
+	}
+	if want, have := `{"values":["a","b","c"]}`+"\n", buf.String(); want != have {
+		t.Errorf("want %q, have %q", want, have)
+	}
+}

--- a/transport/codec/json/json_test.go
+++ b/transport/codec/json/json_test.go
@@ -2,7 +2,6 @@ package json_test
 
 import (
 	"bytes"
-	"reflect"
 	"testing"
 
 	"golang.org/x/net/context"
@@ -25,7 +24,7 @@ func TestDecode(t *testing.T) {
 	if _, err := jsoncodec.New().Decode(context.Background(), buf, &req); err != nil {
 		t.Fatal(err)
 	}
-	if want, have := (request{A: 1, B: "2"}), req; !reflect.DeepEqual(want, have) {
+	if want, have := (request{A: 1, B: "2"}), req; want != have {
 		t.Errorf("want %v, have %v", want, have)
 	}
 }

--- a/transport/http/binding_test.go
+++ b/transport/http/binding_test.go
@@ -1,0 +1,67 @@
+package http_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"golang.org/x/net/context"
+
+	"github.com/peterbourgon/gokit/server"
+	jsoncodec "github.com/peterbourgon/gokit/transport/codec/json"
+	httptransport "github.com/peterbourgon/gokit/transport/http"
+)
+
+func TestBinding(t *testing.T) {
+	type myRequest struct {
+		In int `json:"in"`
+	}
+
+	type myResponse struct {
+		Out int `json:"out"`
+	}
+
+	transform := func(i int) int {
+		return 3 * i // doesn't matter, just do something
+	}
+
+	endpoint := func(_ context.Context, req server.Request) (server.Response, error) {
+		r, ok := req.(*myRequest)
+		if !ok {
+			return nil, fmt.Errorf("not myRequest (%s)", reflect.TypeOf(req))
+		}
+		return myResponse{transform(r.In)}, nil
+	}
+
+	ctx := context.Background()
+	requestType := reflect.TypeOf(myRequest{})
+	codec := jsoncodec.New()
+	binding := httptransport.NewBinding(ctx, requestType, codec, endpoint)
+	server := httptest.NewServer(binding)
+	defer server.Close()
+
+	n := 123
+	requestBody, err := json.Marshal(myRequest{n})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := http.Post(server.URL, "application/json", bytes.NewBuffer(requestBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	var r myResponse
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		t.Fatal(err)
+	}
+
+	if want, have := transform(n), r.Out; want != have {
+		t.Errorf("want %d, have %d", want, have)
+	}
+}


### PR DESCRIPTION
- Use reflection to generate new Request types for codecs
- Codec.Decode takes Request as out parameter, like json.Decode
- Relevant changes to addsvc